### PR TITLE
Added github action to publish the game on web

### DIFF
--- a/.github/workflows/build-webpage.yml
+++ b/.github/workflows/build-webpage.yml
@@ -1,0 +1,64 @@
+name: Build a web page for playing thetris
+
+on:
+  workflow_dispatch:
+
+# Required by github-pages-deploy-action to push pages to the repository
+permissions:
+  contents: write
+
+env:
+  RELEASE_URL: https://api.github.com/repos/tsaarni/thetris/releases/latest
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    # Technically not needed but pubslishing to Github Pages requires it
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    # https://emscripten.org/docs/getting_started/downloads.html
+    - name: Clone emsdk
+      uses: actions/checkout@v3
+      with:
+        repository: emscripten-core/emsdk
+        path: emsdk
+
+    - name: Install emscripten
+      working-directory: emsdk
+      run: |
+        ./emsdk install latest
+        ./emsdk activate latest
+
+    # https://github.com/dreamlayers/em-dosbox
+    - name: Checkout em-dosbox
+      uses: actions/checkout@v3
+      with:
+        repository: dreamlayers/em-dosbox
+        path: em-dosbox
+
+    - name: Compile em-dosbox
+      working-directory: em-dosbox
+      run: |
+        source ${{ github.workspace }}/emsdk/emsdk_env.sh
+        ./autogen.sh
+        emconfigure ./configure
+        make
+
+    - name: Package exe with em-dosbox
+      working-directory: em-dosbox/src
+      run: |
+        source ${{ github.workspace }}/emsdk/emsdk_env.sh
+        curl -LJO $(curl -s $RELEASE_URL | jq -r '.assets[] | select(.name == "THETRIS.EXE") | .browser_download_url')
+        mkdir ${{ github.workspace }}/publish
+        python3 packager.py ${{ github.workspace }}/publish/index THETRIS.EXE
+        cp dosbox.js dosbox.wasm ${{ github.workspace }}/publish
+
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      with:
+        branch: gh-pages
+        folder: publish


### PR DESCRIPTION
Hi @timohaa 👋  

I did a small experiment which I wanted to share with you, in case you are interested to see as well:

This PR includes a (draft of a) github action script, which downloads [emscripten](https://emscripten.org/) and uses it to compile [em-dosbox](https://github.com/dreamlayers/em-dosbox) to webassembly. The script then uses em-dosbox to package `THETRIS.EXE` into a web page and publishes the result to Github Pages.  I cloned the project and created a page of my own, so you can check it here https://tsaarni.github.io/thetris/. It seem to work at least with Chrome and Firefox.

The script requires a pre-built `THETRIS.EXE`. I googled and there is no open source equivalent to `TASM`. It does not seem feasible to compile the game within github action. Instead, I took an approach that the game needs to be manually published as an artifact in project [release page](https://github.com/tsaarni/thetris/releases). I took the liberty to do this on my own clone for this PoC. Then, when the action is (manually) executed, it picks up the latest EXE from there.

Running the action is unnecessarily slow: about 5 minutes. This is because nothing is cached. It always compiles em-dosbox with emscripten from the beginning, even if the source did not change. I also used "latest" of everything; I did not pin dependencies. Executing the action will eventually surely break because of that 🥲 

One more thing: I did not study what options em-dosbox offers. For example, it can be that the generated landing page could be customized and made prettier.
